### PR TITLE
Fixed error that happened in multi-screen environments

### DIFF
--- a/src/javax/media/j3d/JoglPipeline.java
+++ b/src/javax/media/j3d/JoglPipeline.java
@@ -6540,20 +6540,19 @@ class JoglPipeline extends Pipeline {
     		glDrawable.setRealized(false);
     	}
         else {
-
-        	// TODO can't find an implementation which avoids the use of QueryCanvas
-        	// JOGL requires a visible Frame for an onscreen context
-
-        Frame f = new Frame();
-        f.setUndecorated(true);
-        f.setLayout(new BorderLayout());
-
         ContextQuerier querier = new ContextQuerier(cv);
 
 		    AWTGraphicsConfiguration awtConfig =
 		    		(AWTGraphicsConfiguration)Canvas3D.graphicsConfigTable.get(cv.graphicsConfiguration).getPrivateData();
 
 		    QueryCanvas canvas = new QueryCanvas(awtConfig, querier);
+
+        	// TODO can't find an implementation which avoids the use of QueryCanvas
+        	// JOGL requires a visible Frame for an onscreen context
+
+        Frame f = new Frame(canvas.getGraphicsConfiguration());
+        f.setUndecorated(true);
+        f.setLayout(new BorderLayout());
 
         f.add(canvas, BorderLayout.CENTER);
         f.setSize(MIN_FRAME_SIZE, MIN_FRAME_SIZE);


### PR DESCRIPTION
In our environment we have two screens and sometimes we would get this exception when doing `canvas.queryProperties()`:

```
java.lang.IllegalArgumentException: adding a container to a container on a different GraphicsDevice
	at java.awt.Component.checkGD(Component.java:1185)
	at java.awt.Container.addImpl(Container.java:1093)
	at java.awt.Container.add(Container.java:973)
	at javax.media.j3d.JoglPipeline.createQueryContext(JoglPipeline.java:6558)
	at javax.media.j3d.Canvas3D.createQueryContext(Canvas3D.java:4619)
	at javax.media.j3d.Canvas3D.createQueryContext(Canvas3D.java:3616)
	at javax.media.j3d.Renderer.doWork(Renderer.java:461)
	at javax.media.j3d.J3dThread.run(J3dThread.java:271)
```

I traced it and found out that it happens because frame is created with one screen's configuration, while `QueryCanvas` is created with another screen's configuration. This pull request fixes this problem by creating `Frame` with same graphics configuration as `QueryCanvas`
