### PR TITLE
fixed a NPE that happened during offscreen rendering

### DIFF
--- a/src/main/java/org/jogamp/java3d/CanvasViewCache.java
+++ b/src/main/java/org/jogamp/java3d/CanvasViewCache.java
@@ -589,9 +589,11 @@ class CanvasViewCache extends Object {
 	// 0.666x0.666 = 0.444 scaling. This is not a Java3D issue.
 	try {
 		final Graphics2D g2d = (Graphics2D) canvas.getGraphics();
-	    final AffineTransform t = g2d.getTransform();	
-	    hiDPIXScale = t.getScaleX();
-	    hiDPIYScale = t.getScaleY();
+		if (g2d != null) {
+			final AffineTransform t = g2d.getTransform();
+			hiDPIXScale = t.getScaleX();
+			hiDPIYScale = t.getScaleY();
+		}
 	} catch (IllegalComponentStateException e) {}	
 
 	metersPerPixelX = screenViewCache.metersPerPixelX;


### PR DESCRIPTION
In java 3D 1.7.0 offscreen rendering doesn't work anymore. It crashes with the following exception:
```
Exception in thread "J3D-RenderStructureUpdateThread-1" java.lang.NullPointerException
	at org.jogamp.java3d.CanvasViewCache.computeCanvasInfo(CanvasViewCache.java:592)
	at org.jogamp.java3d.CanvasViewCache.doComputeDerivedData(CanvasViewCache.java:513)
	at org.jogamp.java3d.CanvasViewCache.computeDerivedData(CanvasViewCache.java:411)
	at org.jogamp.java3d.Canvas3D.updateViewCache(Canvas3D.java:3783)
	at org.jogamp.java3d.RenderBin.computeViewFrustumBBox(RenderBin.java:4305)
	at org.jogamp.java3d.RenderBin.processMessages(RenderBin.java:1791)
	at org.jogamp.java3d.StructureUpdateThread.doWork(StructureUpdateThread.java:98)
	at org.jogamp.java3d.J3dThread.run(J3dThread.java:271)
```

This error is caused by `CanvasViewCache` dereferencing null `Graphics2D` object in `computeCanvasInfo`. This PR fixes this issue by checking for null before dereferencing.