### PR TITLE
fixed getPixelLocationFromImagePlate(). Now it works on HiDPI screens

### DIFF
--- a/src/main/java/org/jogamp/java3d/CanvasViewCache.java
+++ b/src/main/java/org/jogamp/java3d/CanvasViewCache.java
@@ -2012,9 +2012,9 @@ class CanvasViewCache extends Object {
         // Note: screenPt is in image plate coords, at z=0
 
         // Transform from image plate coords to screen coords
-        pixelLocation.x = (screenX / screenViewCache.metersPerPixelX) - canvasX;
-        pixelLocation.y = screenViewCache.screenHeight - 1 -
-	    (screenY / screenViewCache.metersPerPixelY) - canvasY;
+        pixelLocation.x = ((screenX / screenViewCache.metersPerPixelX) - canvasX) / hiDPIXScale;
+        pixelLocation.y = (screenViewCache.screenHeight - 1 -
+                (screenY / screenViewCache.metersPerPixelY) - canvasY) / hiDPIYScale;
         //System.err.println("pixelLocation = " + pixelLocation);
     }
 


### PR DESCRIPTION
There was an issue with `Canvas3D.getPixelLocationFromImagePlate()` the location of the pixel was improperly scaled on screens with HiDPI scaling on.

Interestingly, there is no problem in `CanvasViewCache.getPixelLocationInImagePlate()`. This method along with `CanvasViewCache.getWindowXInImagePlate()` and `CanvasViewCache.getWindowYInImagePlate()` take care of HiDPI scaling.