### PR TITLE
Updated pipelines so they use linear interpolation when drawing overlays

### DIFF
--- a/src/main/java/org/jogamp/java3d/Jogl2es2Pipeline.java
+++ b/src/main/java/org/jogamp/java3d/Jogl2es2Pipeline.java
@@ -6844,8 +6844,8 @@ class Jogl2es2Pipeline extends Jogl2es2DEPPipeline
 		gl.glPixelStorei(GL.GL_UNPACK_ALIGNMENT, 1);
 		gl.glBindTexture(GL.GL_TEXTURE_2D, objectId);
 		// set up texture parameter
-		gl.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_MAG_FILTER, GL.GL_NEAREST);
-		gl.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_MIN_FILTER, GL.GL_NEAREST);
+		gl.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_MAG_FILTER, GL.GL_LINEAR);
+		gl.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_MIN_FILTER, GL.GL_LINEAR);
 		gl.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_WRAP_S, GL.GL_REPEAT);
 		gl.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_WRAP_T, GL.GL_REPEAT);
 

--- a/src/main/java/org/jogamp/java3d/JoglPipeline.java
+++ b/src/main/java/org/jogamp/java3d/JoglPipeline.java
@@ -7701,8 +7701,8 @@ static boolean hasFBObjectSizeChanged(JoglDrawable jdraw, int width, int height)
         gl.glPixelStorei(GL.GL_UNPACK_ALIGNMENT, 1);
         gl.glBindTexture(GL.GL_TEXTURE_2D, objectId);
         // set up texture parameter
-        gl.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_MAG_FILTER, GL.GL_NEAREST);
-        gl.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_MIN_FILTER, GL.GL_NEAREST);
+        gl.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_MAG_FILTER, GL.GL_LINEAR);
+        gl.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_MIN_FILTER, GL.GL_LINEAR);
         gl.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_WRAP_S, GL.GL_REPEAT);
         gl.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_WRAP_T, GL.GL_REPEAT);
 


### PR DESCRIPTION
I noticed in HiDPI setup that text that we draw on top of 3D scene using `J3DGraphics2D` in `postRender()`  was blocky:

![nearest_neighbor](https://user-images.githubusercontent.com/4856335/73031757-39428300-3dfa-11ea-9a7a-457766800eff.png)

The proposed pull requests changes interpolation for the overlay texture from `GL_NEAREST` to `GL_LINEAR'. This is the result of this change:

![linear](https://user-images.githubusercontent.com/4856335/73031839-73ac2000-3dfa-11ea-8767-54fe2e15dabb.png)

