### PR TITLE
Improved the 2D graphics overlay in Canvas3D.

### DIFF
--- a/src/main/java/org/jogamp/java3d/Canvas3D.java
+++ b/src/main/java/org/jogamp/java3d/Canvas3D.java
@@ -38,6 +38,7 @@ import java.awt.GraphicsEnvironment;
 import java.awt.IllegalComponentStateException;
 import java.awt.Point;
 import java.awt.Window;
+import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Hashtable;
@@ -1577,6 +1578,13 @@ ArrayList<TextureRetained> textureIDResourceTable = new ArrayList<TextureRetaine
 	    if (graphics2D == null)
 		graphics2D = new J3DGraphics2DImpl(this);
 	}
+    // Set graphics transform to the current HiDPI scale
+    if (canvasViewCache != null) {
+        synchronized (canvasViewCache) {
+            graphics2D.setTransform(new AffineTransform(canvasViewCache.getHiDPIXScale(), 0, 0,
+                    canvasViewCache.getHiDPIYScale(), 0, 0));
+        }
+    }
 
 	return graphics2D;
     }
@@ -2835,6 +2843,30 @@ ArrayList<TextureRetained> textureIDResourceTable = new ArrayList<TextureRetaine
 	else {
 	    t.setIdentity();
 	}
+    }
+
+    /**
+     * Retreives the width of the canvas in device pixels (regardless of HIDPI scale)
+     */
+    int getPixelWidth() {
+        if (canvasViewCache != null) {
+            synchronized (canvasViewCache) {
+                return canvasViewCache.getCanvasWidth();
+            }
+        }
+        return getWidth();
+    }
+
+    /**
+     * Retreives the height of the canvas in device pixels (regardless of HIDPI scale)
+     */
+    int getPixelHeight() {
+        if (canvasViewCache != null) {
+            synchronized (canvasViewCache) {
+                return canvasViewCache.getCanvasHeight();
+            }
+        }
+        return getHeight();
     }
 
     /**

--- a/src/main/java/org/jogamp/java3d/CanvasViewCache.java
+++ b/src/main/java/org/jogamp/java3d/CanvasViewCache.java
@@ -589,11 +589,9 @@ class CanvasViewCache extends Object {
 	// 0.666x0.666 = 0.444 scaling. This is not a Java3D issue.
 	try {
 		final Graphics2D g2d = (Graphics2D) canvas.getGraphics();
-		if (g2d != null) {
-			final AffineTransform t = g2d.getTransform();
-			hiDPIXScale = t.getScaleX();
-			hiDPIYScale = t.getScaleY();
-		}
+	    final AffineTransform t = g2d.getTransform();	
+	    hiDPIXScale = t.getScaleX();
+	    hiDPIYScale = t.getScaleY();
 	} catch (IllegalComponentStateException e) {}	
 
 	metersPerPixelX = screenViewCache.metersPerPixelX;

--- a/src/main/java/org/jogamp/java3d/CanvasViewCache.java
+++ b/src/main/java/org/jogamp/java3d/CanvasViewCache.java
@@ -589,9 +589,11 @@ class CanvasViewCache extends Object {
 	// 0.666x0.666 = 0.444 scaling. This is not a Java3D issue.
 	try {
 		final Graphics2D g2d = (Graphics2D) canvas.getGraphics();
-	    final AffineTransform t = g2d.getTransform();	
-	    hiDPIXScale = t.getScaleX();
-	    hiDPIYScale = t.getScaleY();
+		if (g2d != null) {
+			final AffineTransform t = g2d.getTransform();
+			hiDPIXScale = t.getScaleX();
+			hiDPIYScale = t.getScaleY();
+		}
 	} catch (IllegalComponentStateException e) {}	
 
 	metersPerPixelX = screenViewCache.metersPerPixelX;

--- a/src/main/java/org/jogamp/java3d/CanvasViewCache.java
+++ b/src/main/java/org/jogamp/java3d/CanvasViewCache.java
@@ -1803,6 +1803,14 @@ class CanvasViewCache extends Object {
 	return canvasHeight;
     }
 
+    double getHiDPIXScale() {
+    	return hiDPIXScale;
+	}
+
+	double getHiDPIYScale() {
+    	return hiDPIYScale;
+	}
+
     double getPhysicalWindowWidth() {
 	return physicalWindowWidth;
     }

--- a/src/main/java/org/jogamp/java3d/J3DGraphics2DImpl.java
+++ b/src/main/java/org/jogamp/java3d/J3DGraphics2DImpl.java
@@ -115,8 +115,10 @@ final class J3DGraphics2DImpl extends J3DGraphics2D {
 	if (!initCtx) {
 	    abgr = ((canvas3d.extensionsSupported & Canvas3D.EXT_ABGR) != 0);
 
-	    width = canvas3d.getWidth();
-	    height = canvas3d.getHeight();
+	    // We use actual pixel sizes that depend
+		// on the current HiDPI setting
+		width = canvas3d.getPixelWidth();
+		height = canvas3d.getPixelHeight();
 	    initTexMap = false;
 
 	    if (width <= 0) {
@@ -135,6 +137,8 @@ final class J3DGraphics2DImpl extends J3DGraphics2D {
 	    g3dImage = new BufferedImage(width, height,
 					 (abgr ? BufferedImage.TYPE_4BYTE_ABGR:
 					  BufferedImage.TYPE_INT_ARGB));
+		// No need to set graphics affine transform to HiDPI scaling
+		// as it will be reset in Canvas3D.getGraphics2D()
 	    offScreenGraphics2D = g3dImage.createGraphics();
 	    clearOffScreen();
 	    if (!abgr) {


### PR DESCRIPTION
I noticed that the whole reason for pull request #5  was the fact that on HiDPI screens the image for 2D overlay was created smaller (i.e. using `Canvas3D` getWidth() and getHeight()). As the result, the overlay was always upscaled on HiDPI screens and produced blurry results. 

For example, without HiDPI enabled on my 1920x1200 screen the canvas size is 1920x1137, with HiDPI set to 175% the size is 1097x622 although the amount of pixels is almost identical (the title bar width is slightly different) in both cases. Therefore the in HiDPI case the overlay image was only 1097x622 and it was upscaled to about 1920x1200 producing blurry artifacts with changes from #5. 

In this PR I tried to fix that issue by creating overlay image using proper canvas size in screen pixels and scaling `Graphics2D` (this is similar to what Java does on HiDPI screens).

This is a screen shot of my simple test program that I run at 175% scaling before applying this fix:
![before](https://user-images.githubusercontent.com/4856335/73216617-89c82200-4113-11ea-8e99-568dd23d133d.png)
You can see that the text and line are blurry and the width of the lines is incorrect. 
This is how this looks after applying the proposed changes:
![after](https://user-images.githubusercontent.com/4856335/73216694-b2501c00-4113-11ea-8922-c5d4db031e89.png)

Hope this all makes sense. 