### PR TITLE
fixed an issue with J3DGraphics2DImpl.clearOffScreen()

### DIFF
--- a/src/main/java/org/jogamp/java3d/J3DGraphics2DImpl.java
+++ b/src/main/java/org/jogamp/java3d/J3DGraphics2DImpl.java
@@ -1179,11 +1179,17 @@ final class J3DGraphics2DImpl extends J3DGraphics2D {
     void clearOffScreen() {
 	Composite comp = offScreenGraphics2D.getComposite();
 	Color c = offScreenGraphics2D.getColor();
+	AffineTransform transform = offScreenGraphics2D.getTransform();
+	// Reset offScreenGraphics2D transform to identity because xmin, ymin, xmax and ymax
+	// are in image space and offScreenGraphics2D might have a
+	// different transform set (i.e. HiDPI transform)
+	offScreenGraphics2D.setTransform(new AffineTransform());
 	offScreenGraphics2D.setComposite(AlphaComposite.Src);
 	offScreenGraphics2D.setColor(blackTransparent);
 	offScreenGraphics2D.fillRect(xmin, ymin, (xmax-xmin), (ymax-ymin));
 	offScreenGraphics2D.setComposite(comp);
 	offScreenGraphics2D.setColor(c);
+	offScreenGraphics2D.setTransform(transform);
     }
 
     /**


### PR DESCRIPTION
This is another issue that I noticed while working with HiDPI screens. I guess I should have seen it earlier while working on PR #7. It could also become an issue without HiDPI in cases when custom `AffineTransform` is set into the Graphics.

Basically, `xmin`, `xmax`, `ymin` and `ymax` are in 2D buffered image space (I checked all usages and it is consistent everywhere). So, when offscreen graphics is cleared we need to reset its transform to identity (i.e., pure 2D buffered image coordinates) and then clear it.