### PR TITLE
HiDPI fix for Raster reading operation

### DIFF
--- a/src/main/java/org/jogamp/java3d/Canvas3D.java
+++ b/src/main/java/org/jogamp/java3d/Canvas3D.java
@@ -2848,7 +2848,7 @@ ArrayList<TextureRetained> textureIDResourceTable = new ArrayList<TextureRetaine
     /**
      * Retreives the width of the canvas in device pixels (regardless of HIDPI scale)
      */
-    int getPixelWidth() {
+    public int getPixelWidth() {
         if (canvasViewCache != null) {
             synchronized (canvasViewCache) {
                 return canvasViewCache.getCanvasWidth();
@@ -2860,7 +2860,7 @@ ArrayList<TextureRetained> textureIDResourceTable = new ArrayList<TextureRetaine
     /**
      * Retreives the height of the canvas in device pixels (regardless of HIDPI scale)
      */
-    int getPixelHeight() {
+    public int getPixelHeight() {
         if (canvasViewCache != null) {
             synchronized (canvasViewCache) {
                 return canvasViewCache.getCanvasHeight();

--- a/src/main/java/org/jogamp/java3d/GraphicsContext3D.java
+++ b/src/main/java/org/jogamp/java3d/GraphicsContext3D.java
@@ -2255,7 +2255,6 @@ public int numSounds() {
         }
 
         RasterRetained ras = (RasterRetained)raster.retained;
-        Dimension canvasSize = canvas3d.getSize();
         Dimension rasterSize = new Dimension();
         ImageComponent2DRetained image = ras.image;
 
@@ -2348,7 +2347,7 @@ public int numSounds() {
 
                 Pipeline.getPipeline().readRaster(canvas3d.ctx,
                         ras.type, rasterSrcOffset.x, rasterSrcOffset.y,
-                        rasterSize.width, rasterSize.height, canvasSize.height,
+                        rasterSize.width, rasterSize.height, canvas3d.getPixelHeight(),
                         imageDataType,
                         imageFormatType,
                         imageBuffer,


### PR DESCRIPTION
In our software we extensively use depth buffer obtained from `GraphicsContext3D` of `Canvas3D`. We use it mainly for overlaying text information on top of the scene. This text must have depth and  is partially hidden by scene objects.

Recently I noticed that on screens with HiDPI enabled this text data is displayed incorrectly: it was shown, when it should have been obscured by scene objects. I rendered depth buffer into an image and noticed that it was broken. The following images show scene on the left and the obtained depth buffer on the right. One image is captured at 100% screen scale (i.e. HiDPI off) while the other one is taken at 150%:

![before_100](https://user-images.githubusercontent.com/4856335/74556012-311dc500-4f1a-11ea-931a-de75a2373f6b.png)

![before_150](https://user-images.githubusercontent.com/4856335/74556018-34b14c00-4f1a-11ea-9a6b-c2b1729fe002.png)

Turned out that wrong canvas height was passed to `Pipeline.readRaster()`. The pipeline reads raster in pixels and *device* canvas size was passed to this method. This PR fixes this issue by passing canvas size in pixels. 

The following images show how the test scene looks like after this fix applied (again, first one is 100%, the second one is 150%):

![after_100](https://user-images.githubusercontent.com/4856335/74556209-c456fa80-4f1a-11ea-8779-3ffd3bab0ed8.png)

![after_150](https://user-images.githubusercontent.com/4856335/74556220-c91bae80-4f1a-11ea-882d-def95ff624a1.png)

In the second commit of this PR I propose to make `Canvas3D.getPixelWidth()` and `Canvas3D.getPixelHeight()` public so the users of the library can get canvas dimensions in pixels without workarounds such as this:
```java
            Graphics2D g = canvas.getGraphics2D();
            AffineTransform transform = g.getTransform();
            int canvasWidthPixels = (int) (canvas.getWidth() * transform.getScaleX());
            int canvasHeightPixels = (int) (canvas.getHeight() * transform.getScaleY());
```

