### PR TITLE
Fixed an issue with shared readRasterReady variable in GraphicsContext3D

### DIFF
--- a/src/main/java/org/jogamp/java3d/Renderer.java
+++ b/src/main/java/org/jogamp/java3d/Renderer.java
@@ -39,6 +39,7 @@ import java.awt.image.ImageObserver;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.concurrent.CountDownLatch;
 import java.util.logging.Level;
 
 
@@ -691,7 +692,7 @@ ArrayList<TextureRetained> textureIDResourceTable = new ArrayList<TextureRetaine
                         break;
                     case GraphicsContext3D.READ_RASTER:
                         canvas.graphicsContext3D.doReadRaster(
-				(Raster)m[nmesg].args[2]);
+				(Raster)m[nmesg].args[2], (CountDownLatch) m[nmesg].args[3]);
                         break;
 		    case GraphicsContext3D.SET_APPEARANCE:
 			canvas.graphicsContext3D.doSetAppearance(


### PR DESCRIPTION
I noticed another problem with `GraphicsContext3D.readRaster()`. Basically, when called from any thread  except renderer thread it sends a message to a renderer thread to save raster and then waits for completion:
```java
            readRasterReady = false;
            sendRenderMessage(false, GraphicsContext3D.READ_RASTER, raster, null);
	    while (!readRasterReady) {
		MasterControl.threadYield();
	    }
```
The only problem is that `readRasterReady` variable is an instance varaible of  `GraphicsContext3D`, so if several calls to `readRaster()` are made from different threads they will all wait for the first one to render and will get empty images. 

This PR fixes this issue by using `CountdownLatch` for each separate call to `readRaster()`. Moreover the busy waiting section:
```java
           while (!readRasterReady) {
		MasterControl.threadYield();
	    }
```
was removed in favor of proper latch waiting mechanism.