### PR TITLE
Fixes to Canvas3D.getPixelWidth() and Canvas3D.getPixelHeight()

### DIFF
--- a/src/main/java/org/jogamp/java3d/Canvas3D.java
+++ b/src/main/java/org/jogamp/java3d/Canvas3D.java
@@ -2851,7 +2851,7 @@ ArrayList<TextureRetained> textureIDResourceTable = new ArrayList<TextureRetaine
     public int getPixelWidth() {
         if (canvasViewCache != null) {
             synchronized (canvasViewCache) {
-                return canvasViewCache.getCanvasWidth();
+                return (int) (getWidth() * canvasViewCache.getHiDPIXScale());
             }
         }
         return getWidth();
@@ -2863,7 +2863,7 @@ ArrayList<TextureRetained> textureIDResourceTable = new ArrayList<TextureRetaine
     public int getPixelHeight() {
         if (canvasViewCache != null) {
             synchronized (canvasViewCache) {
-                return canvasViewCache.getCanvasHeight();
+                return (int) (getHeight() * canvasViewCache.getHiDPIYScale());
             }
         }
         return getHeight();


### PR DESCRIPTION
Sometimes, if canvas is resized, CanvasViewCache is not updated before a frame is rendered. 
I suspect this is due to the fact that Java3D threads are not synchronized in any way with EDT thread.

As the result of this the width and height values in the cache might be incorrect. This fix changes how Canvas3D provides its width and height in pixels. Now, instead of taking these values from the cache, they are calculated on the fly using actual `Component` width and height.